### PR TITLE
Relax jekyll dependency to allow v4

### DIFF
--- a/bibsonomy-jekyll.gemspec
+++ b/bibsonomy-jekyll.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.licenses = ['GPL-3.0']
   s.files    = `git ls-files -z`.split("\x0")
 
-  s.add_dependency 'jekyll', '~> 3.8', '>= 3.8.3'
+  s.add_dependency 'jekyll', '>= 3.8.3', "< 5.0"
   s.add_dependency 'bibsonomy', '~> 0.4', '>= 0.4.16'
 
   s.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
according to https://jekyllrb.com/news/2019/08/20/jekyll-4-0-0-released/#upgrading-